### PR TITLE
Translation type varchar -> text

### DIFF
--- a/Resources/config/doctrine/Translation.orm.xml
+++ b/Resources/config/doctrine/Translation.orm.xml
@@ -15,7 +15,7 @@
 
         <field name="value"
                column="value"
-               type="string"/>
+               type="text"/>
 
         <many-to-one target-entity="ServerGrove\Bundle\TranslationEditorBundle\Entity\Entry"
                      field="entry"


### PR DESCRIPTION
In a project of ours we needed some long strings to be stored.

In order to do so, using varchar is not an option.

Example case might be if one has all the email messages that would be sent by the application upon given event and need them to be translatable. You cannot always abide the 255 characters limitation.
