### PR TITLE
bugfix: unable to set translation

### DIFF
--- a/Resources/views/Editor/index.html.twig
+++ b/Resources/views/Editor/index.html.twig
@@ -295,7 +295,7 @@
                         <span class="label warning">Duplicate</span>
                     {% endif %}
 
-                    {% if not translation %}
+                    {% if not translation or translation.getValue() is empty %}
                         <span class="label important" onclick="showTranslationEditForm('{{loop.parent.loop.index}}-{{locale}}')">Missing</span>
                     {% endif %}
                 </div>


### PR DESCRIPTION
Example case:
1. Set a translation
2. Save
3. Click and remove all the text
4. Save

After you perform these steps, you cannot set a value for a given translation on a given language simply because you cannot click it. This PR fixes the issue.
