### PR TITLE
Removed useless conf and fixed filename during export

### DIFF
--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -166,7 +166,7 @@ class ExportCommand extends AbstractCommand
             $catalogue = new MessageCatalogue((string) $locale);
 
             foreach ($translationList as $translation) {
-                $catalogue->set($translation->getEntry()->getAlias(), $translation->getValue(), $translation->getEntry()->getDomain());
+                $catalogue->set($translation->getEntry()->getAlias(), $translation->getValue(), $translation->getEntry()->getFilename());
             }
 
             $writer->writeTranslations($catalogue, $translation->getEntry()->getFormat(), array('path' => dirname($filePath)));

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,15 +35,6 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
-                ->arrayNode('exporter')
-                    ->children()
-                        ->scalarNode('type')
-                            ->cannotBeOverwritten()
-                            ->isRequired()
-                            ->cannotBeEmpty()
-                        ->end()
-                    ->end()
-                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/ServerGroveTranslationEditorExtension.php
+++ b/DependencyInjection/ServerGroveTranslationEditorExtension.php
@@ -23,7 +23,5 @@ class ServerGroveTranslationEditorExtension extends \Symfony\Component\HttpKerne
 
         $container->setParameter($this->getAlias() . '.storage.type', $config['storage']['type']);
         $container->setParameter($this->getAlias() . '.storage.manager', $config['storage']['manager']);
-
-        $container->setParameter($this->getAlias() . '.exporter.type', $config['exporter']['type']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ A sample configuration (in your config_dev.yml):
       storage:
         type: server_grove_translation_editor.storage.orm
         manager: doctrine.orm.entity_manager
-      exporter:
-        type: server_grove_translation_editor.exporter.yaml
 
 Add the routing configuration to app/config/routing_dev.yml
 


### PR DESCRIPTION
- Removed useless conf: 'exporter.type'. The dumper of the symfony core is used instead.
- Fixed filename during export: the domain used by the translations catalog should correspond to the translation filename.
